### PR TITLE
protoの詳細にあるuserの名前から詳細へ

### DIFF
--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -4,7 +4,7 @@
       <p class="prototype__hedding">
         <%= @prototype.title %>
       </p>
-      <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
+      <%= link_to "by #{@prototype.user.name}", "/users/#{@prototype.user_id}/", class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       <% if user_signed_in? && @prototype.user_id == current_user.id%>
         <div class="prototype__manage" >


### PR DESCRIPTION
# what
prototypeの詳細画面のuserの名前からuserの詳細に飛ぶようにしました
# why
userの詳細はおそらくこれで最後