### PR TITLE
renderからredirect_toへ変更

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -23,7 +23,7 @@ class PrototypesController < ApplicationController
   def edit
     @prototype = Prototype.find(params[:id])
     if user_signed_in? && @prototype.user_id != current_user.id
-      render action: :index
+      redirect_to action: :index
     end
   end
 


### PR DESCRIPTION
# what
renderからredirect_toへ変更

# Why
editアクションで他のユーザーが編集画面に行こうとした時にトップページに遷移させる実装で、
renderだとトップページに投稿一覧が表示されないことに気づいた為、redirect_toに変更しました！